### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The implementation follows all Promise/A+ specs, excepting the ones not aplicabl
 The current implementation doesn't yet implement circular promise chain detection, support for this will be added later on.
 
 ## New
-Added support for Swift, check the CKSwiftPromise framework (or CKSwiftPromise spec if you're using Cocoapods)
+Added support for Swift, check the CKSwiftPromise framework (or CKSwiftPromise spec if you're using CocoaPods)
 
 ## Installation
 
@@ -20,7 +20,7 @@ Added support for Swift, check the CKSwiftPromise framework (or CKSwiftPromise s
 2. Add the `CKPromise.xcproject` to your project/workspace
 3. Link against the `CKPromise` or/and `CKSwiftPromise` targets
 
-### Via Cocoapods
+### Via CocoaPods
 1. Add `pod 'CKPromise'`, or `pod 'CKSwiftPromise` to your Podfile
 2. Run `pod install`
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
